### PR TITLE
Update to using latest beta, to try fixing tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 2
   noarch: python
-  script: python -m pip install --no-deps --ignore-installed . && jupyter-nbextension enable qgrid --py --sys-prefix
+  script: jupyter-nbextension disable qgrid --py --sys-prefix && python -m pip install --no-deps --ignore-installed . && jupyter-nbextension enable qgrid --py --sys-prefix
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 2
   noarch: python
-  script: jupyter-nbextension disable qgrid --py --sys-prefix && python -m pip install --no-deps --ignore-installed . && jupyter-nbextension enable qgrid --py --sys-prefix
+  script: jupyter-nbextension disable qgrid --py --sys-prefix; python -m pip install --no-deps --ignore-installed . && jupyter-nbextension enable qgrid --py --sys-prefix
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.0.1" %}
-{% set sha256 = "d1f931c09aa56dcd3923cc4a4ff2aaadf5a17ee1a91a22473ae6fdb89aaa143c" %}
+{% set version = "1.0.2" %}
+{% set sha256 = "987d2cf95b1d623cc498bf92fcdf7fa03261d124a0b1a9a68b97f3ea524cb42c" %}
 
 package:
   name: qgrid

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - ipywidgets >=7.0.0
 
 test:
+  requires:
+    - pytest
   imports:
     - qgrid
     - qgrid.tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 build:
   number: 2
   noarch: python
+  # disable if already installed
   script: (jupyter-nbextension disable qgrid --py --sys-prefix || true) && python -m pip install --no-deps --ignore-installed . && jupyter-nbextension enable qgrid --py --sys-prefix
 
 requirements:
@@ -35,8 +36,10 @@ test:
     - qgrid
     - qgrid.tests
     - pytest
-#  commands:
-#    - pytest
+  source_files:
+    - qgrid/tests
+  commands:
+    - pytest
 
 about:
   home: https://github.com/quantopian/qgrid

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 2
   noarch: python
-  script: python -m pip install --no-deps --ignore-installed .
+  script: python -m pip install --no-deps --ignore-installed . && jupyter-nbextension enable qgrid --py --sys-prefix
 
 requirements:
   build:
@@ -33,8 +33,8 @@ test:
     - qgrid
     - qgrid.tests
     - pytest
-  commands:
-    - pytest
+#  commands:
+#    - pytest
 
 about:
   home: https://github.com/quantopian/qgrid

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 2
   noarch: python
-  script: python -c "import qgrid" && jupyter-nbextension disable qgrid --py --sys-prefix; python -m pip install --no-deps --ignore-installed . && jupyter-nbextension enable qgrid --py --sys-prefix
+  script: (jupyter-nbextension disable qgrid --py --sys-prefix || true) && python -m pip install --no-deps --ignore-installed . && jupyter-nbextension enable qgrid --py --sys-prefix
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
+  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -29,6 +30,9 @@ test:
   imports:
     - qgrid
     - qgrid.tests
+    - pytest
+  commands:
+    - pytest
 
 about:
   home: https://github.com/quantopian/qgrid

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - pip
     - notebook >=4.0.0
+    - ipywidgets >=7.0.0
   run:
     - python
     - notebook >=4.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - pip
     - notebook >=4.0.0
+    - pandas >=0.17.0
     - ipywidgets >=7.0.0
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 2
   noarch: python
-  script: jupyter-nbextension disable qgrid --py --sys-prefix; python -m pip install --no-deps --ignore-installed . && jupyter-nbextension enable qgrid --py --sys-prefix
+  script: python -c "import qgrid" && jupyter-nbextension disable qgrid --py --sys-prefix; python -m pip install --no-deps --ignore-installed . && jupyter-nbextension enable qgrid --py --sys-prefix
 
 requirements:
   build:

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,3 +1,0 @@
-@echo off
-
-"%PREFIX%\Scripts\jupyter-nbextension.exe" enable qgrid --py --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,1 +1,0 @@
-"${PREFIX}/bin/jupyter-nbextension" enable qgrid --py --sys-prefix > /dev/null 2>&1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,3 +1,0 @@
-@echo off
-
-"%PREFIX%\Scripts\jupyter-nbextension.exe" disable qgrid --py --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,1 +1,0 @@
-"${PREFIX}/bin/jupyter-nbextension" disable qgrid --py --sys-prefix > /dev/null 2>&1


### PR DESCRIPTION
Bumps the version of qgrid to get a new version in which tests will run with python 2.  See https://github.com/conda-forge/qgrid-feedstock/pull/3 for more info.